### PR TITLE
Feature: JSON config for chat filter.

### DIFF
--- a/common/src/main/java/mc/smpessentials/chatfilter/ChatFilter.java
+++ b/common/src/main/java/mc/smpessentials/chatfilter/ChatFilter.java
@@ -1,6 +1,7 @@
 package mc.smpessentials.chatfilter;
 
 import dev.architectury.event.events.common.ChatEvent;
+import dev.architectury.event.events.common.LifecycleEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -16,14 +17,17 @@ import java.util.regex.Pattern;
  * Registers a decorate callback that replaces offending word tokens with "****".
  */
 public final class ChatFilter {
-    private static final Pattern WORD = Pattern.compile("\\p{L}+");
+    private static final Pattern WORD = Pattern.compile("[\\p{L}\\p{N}_'@\\-]+");
     private ChatFilter() {}
 
     /**
-     * Registers the chat decorate event. Must be called once during common init.
+     * Registers the chat decorate event. 
+     * + Server start autoload
+     * Must be called once during common init.
      */
     public static void init() {
         ChatEvent.DECORATE.register(ChatFilter::onDecorate);
+        LifecycleEvent.SERVER_STARTED.register(server -> ChatFilterConfig.mergeFromConfig(server));
     }
     /*
      * Chat decorate callback that inspects the raw message and replaces any word-token

--- a/common/src/main/java/mc/smpessentials/chatfilter/ChatFilterCommands.java
+++ b/common/src/main/java/mc/smpessentials/chatfilter/ChatFilterCommands.java
@@ -61,6 +61,14 @@ public final class ChatFilterCommands {
                     return words.size();
                 })
             )
+            .then(Commands.literal("load")
+                .executes(ctx -> {
+                    var src = ctx.getSource();
+                    var res = ChatFilterConfig.mergeFromConfig(src.getServer());
+                    src.sendSuccess(() -> Component.literal("Loaded " + res.added() + " new words (total " + res.total() + ")."), false);
+                    return res.added();
+                })
+            )
         );
     }
 }

--- a/common/src/main/java/mc/smpessentials/chatfilter/ChatFilterConfig.java
+++ b/common/src/main/java/mc/smpessentials/chatfilter/ChatFilterConfig.java
@@ -1,0 +1,35 @@
+package mc.smpessentials.chatfilter;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import mc.smpessentials.config.ConfigIO;
+import net.minecraft.server.MinecraftServer;
+
+/** Loads chat filter words from quackedsmp.json and merges into SavedData. */
+public final class ChatFilterConfig {
+    private ChatFilterConfig() {}
+
+    public static Result mergeFromConfig(MinecraftServer server) {
+        ChatFilterSavedData data = ChatFilter.getData(server);
+        int before = data.snapshot().size();
+
+        JsonObject root = ConfigIO.readOrCreate();
+        if (root.has("chatfilter") && root.get("chatfilter").isJsonObject()) {
+            JsonObject cf = root.getAsJsonObject("chatfilter");
+            if (cf.has("contents") && cf.get("contents").isJsonArray()) {
+                JsonArray arr = cf.getAsJsonArray("contents");
+                for (JsonElement el : arr) {
+                    if (el.isJsonPrimitive() && el.getAsJsonPrimitive().isString()) {
+                        data.add(el.getAsString());
+                    }
+                }
+            }
+        }
+
+        int after = data.snapshot().size();
+        return new Result(Math.max(after - before, 0), after);
+    }
+
+    public record Result(int added, int total) {}
+}

--- a/common/src/main/java/mc/smpessentials/config/ConfigIO.java
+++ b/common/src/main/java/mc/smpessentials/config/ConfigIO.java
@@ -1,0 +1,60 @@
+package mc.smpessentials.config;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import dev.architectury.platform.Platform;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** Shared config file helpers for all packages. */
+public final class ConfigIO {
+    private static final String FILE_NAME = "quackedsmp.json";
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+
+    private ConfigIO() {}
+
+    public static Path path() {
+        return Platform.getConfigFolder().resolve(FILE_NAME);
+    }
+
+    /** Ensures a file exists and returns its parsed JSON; writes a minimal default if missing or empty. */
+    public static JsonObject readOrCreate() {
+        Path p = path();
+        try {
+            Files.createDirectories(p.getParent());
+            if (!Files.exists(p) || Files.size(p) == 0) {
+                JsonObject root = defaultJson();
+                Files.writeString(p, GSON.toJson(root), StandardCharsets.UTF_8);
+                return root;
+            }
+            String s = Files.readString(p, StandardCharsets.UTF_8);
+            JsonObject obj = GSON.fromJson(s, JsonObject.class);
+            if (obj == null) obj = defaultJson();
+            // Backfill missing sections for forward-compat
+            if (!obj.has("chatfilter") || !obj.get("chatfilter").isJsonObject()) {
+                obj.add("chatfilter", defaultJson().getAsJsonObject("chatfilter"));
+                Files.writeString(p, GSON.toJson(obj), StandardCharsets.UTF_8);
+            }
+            return obj;
+        } catch (IOException e) {
+            // Fall back to default in-memory config when IO fails
+            return defaultJson();
+        }
+    }
+
+    private static JsonObject defaultJson() {
+        JsonObject root = new JsonObject();
+        JsonObject cf = new JsonObject();
+        com.google.gson.JsonArray arr = new com.google.gson.JsonArray();
+        arr.add("word1");
+        arr.add("word2");
+        cf.add("contents", arr);
+        root.add("chatfilter", cf);
+        return root;
+    }
+
+}


### PR DESCRIPTION
# added config for plugin.
#7 
currently only adds banned words to the chatfilter on sever start or with /chatfilter load.

- in the future load will move out of chatfilter commands 
- or a new command will be added for reloading the rest of the config.

> Json config format

`{
  "chatfilter": {
    "contents": [
      "word1",
      "word2"
    ]
  }
}`