### PR TITLE
26.1.2 hotfix

### DIFF
--- a/common/src/main/java/mc/smpessentials/commands/EndResetLogic.java
+++ b/common/src/main/java/mc/smpessentials/commands/EndResetLogic.java
@@ -74,10 +74,10 @@ public class EndResetLogic {
             cleanUpOldFight(sEndLevel);
             discardEndEntities(sEndLevel);
 
-            // 3. Mark the DIM1 folder for deletion on shutdown
-            Path dim1Dir = server.getWorldPath(LevelResource.ROOT).resolve("DIM1");
-            Path marker = dim1Dir.resolve("RESET_PENDING");
-            if (!Files.exists(dim1Dir)) Files.createDirectories(dim1Dir);
+            // 3. Mark the End folder for deletion on shutdown
+            Path endDir = server.getWorldPath(LevelResource.ROOT).resolve("dimensions/minecraft/the_end");
+            Path marker = endDir.resolve("RESET_PENDING");
+            if (!Files.exists(endDir)) Files.createDirectories(endDir);
             Files.createFile(marker);
 
             // 4. Trigger a live dragon fight reset in the current level too
@@ -90,19 +90,20 @@ public class EndResetLogic {
         }
     }
 
-    // Deletes End region/data/poi files if a RESET_PENDING marker exists. Called from the server-stopping event.
+    // Deletes End region/entities/data/poi files if a RESET_PENDING marker exists. Called from the server-stopping event.
     public static void onServerStopping(MinecraftServer server) {
         try {
-            Path dim1Dir = server.getWorldPath(LevelResource.ROOT).resolve("DIM1");
-            Path marker = dim1Dir.resolve("RESET_PENDING");
-            
+            Path endDir = server.getWorldPath(LevelResource.ROOT).resolve("dimensions/minecraft/the_end");
+            Path marker = endDir.resolve("RESET_PENDING");
+
             if (Files.exists(marker)) {
                 mc.smpessentials.SmpUtilsMod.LOGGER.info("[QuackedSMP] Performing scheduled End dimension reset...");
 
                 // At this point, the server is shutting down, so we can attempt to delete files
-                deleteDirectoryContents(dim1Dir.resolve("region"));
-                deleteDirectoryContents(dim1Dir.resolve("data"));
-                deleteDirectoryContents(dim1Dir.resolve("poi"));
+                deleteDirectoryContents(endDir.resolve("region"));
+                deleteDirectoryContents(endDir.resolve("entities"));
+                deleteDirectoryContents(endDir.resolve("data"));
+                deleteDirectoryContents(endDir.resolve("poi"));
 
                 Files.deleteIfExists(marker);
                 mc.smpessentials.SmpUtilsMod.LOGGER.info("[QuackedSMP] End dimension reset complete.");

--- a/common/src/main/java/mc/smpessentials/dims/DimManager.java
+++ b/common/src/main/java/mc/smpessentials/dims/DimManager.java
@@ -75,10 +75,6 @@ public final class DimManager {
 
     private static final Logger LOGGER = LogManager.getLogger("DimManager");
 
-    // Dims queued for removal from level.dat on next server stop (see scrubLevelDat)
-    private static final Set<String> pendingLevelDatRemovals =
-            Collections.synchronizedSet(new HashSet<>());
-
     // Tracks which loaded dims are ether-type to avoid SavedData lookups on every tick
     private static final Set<String> etherDimIds =
             Collections.synchronizedSet(new HashSet<>());
@@ -108,8 +104,8 @@ public final class DimManager {
     }
 
     // Evicts all players, saves, closes, and removes the dimension. Deletes chunk data, datapack
-    // JSON, and BlueMap map config so it does not re-register on restart. Queues a level.dat scrub
-    // for server stop. Returns null on success or an error message on failure.
+    // JSON, and BlueMap map config so it does not re-register on restart.
+    // Returns null on success or an error message on failure.
     public static String destroy(MinecraftServer server, String id) {
         Identifier loc;
         try {
@@ -160,11 +156,6 @@ public final class DimManager {
         levels.remove(dimKey);
         etherDimIds.remove(loc.toString());
         DimSavedData.get(server).remove(id);
-        // Queue this dim for removal from level.dat on the next server stop.
-        // Vanilla bakes datapack-registered dimensions into level.dat on first load and
-        // re-registers them from there on subsequent restarts even if the datapack JSON
-        // is deleted. scrubLevelDat() patches the file after the server's own save completes.
-        pendingLevelDatRemovals.add(loc.toString());
         // Force-write to disk immediately so the deletion survives a crash or fast restart
         server.overworld().getDataStorage().saveAndJoin();
 
@@ -250,41 +241,6 @@ public final class DimManager {
             }
         } catch (IOException e) {
             LOGGER.error("Failed to scan playerdata directory: {}", e.getMessage());
-        }
-    }
-
-    // Patches level.dat after the server's own save to remove deleted dim IDs from
-    // WorldGenSettings.dimensions. Must be called from the server-stopped event.
-    public static void scrubLevelDat(MinecraftServer server) {
-        if (pendingLevelDatRemovals.isEmpty()) return;
-
-        Path levelDat = server.getWorldPath(LevelResource.ROOT).resolve("level.dat");
-        try {
-            CompoundTag root = NbtIo.readCompressed(levelDat, NbtAccounter.unlimitedHeap());
-            // getCompound returns Optional<CompoundTag> in 1.21.11
-            Optional<CompoundTag> dimsOpt = root.getCompound("Data")
-                    .flatMap(d -> d.getCompound("WorldGenSettings"))
-                    .flatMap(w -> w.getCompound("dimensions"));
-
-            if (dimsOpt.isEmpty()) return;
-            CompoundTag dimensions = dimsOpt.get();
-
-            boolean modified = false;
-            for (String dimId : pendingLevelDatRemovals) {
-                if (dimensions.contains(dimId)) {
-                    dimensions.remove(dimId);
-                    LOGGER.info("Scrubbed {} from level.dat WorldGenSettings", dimId);
-                    modified = true;
-                }
-            }
-
-            if (modified) {
-                NbtIo.writeCompressed(root, levelDat);
-            }
-        } catch (IOException e) {
-            LOGGER.error("Failed to scrub deleted dimensions from level.dat: {}", e.getMessage());
-        } finally {
-            pendingLevelDatRemovals.clear();
         }
     }
 

--- a/common/src/main/java/mc/smpessentials/dims/DimManager.java
+++ b/common/src/main/java/mc/smpessentials/dims/DimManager.java
@@ -215,7 +215,7 @@ public final class DimManager {
     // minecraft:overworld for any player saved in the given dimension.
     // This prevents a fatal server crash when the player reconnects.
     private static void relocateOfflinePlayers(MinecraftServer server, String deletedDimId) {
-        Path playerDataDir = server.getWorldPath(LevelResource.ROOT).resolve("playerdata");
+        Path playerDataDir = server.getWorldPath(LevelResource.PLAYER_DATA_DIR);
         if (!java.nio.file.Files.isDirectory(playerDataDir)) return;
 
         // Collect UUIDs of currently online players — their data is managed in memory.
@@ -313,7 +313,7 @@ public final class DimManager {
     private static void repairOrphanedPlayers(MinecraftServer server) {
         Map<ResourceKey<Level>, ServerLevel> levels =
                 ((MinecraftServerMixin) server).getLevels();
-        Path playerDataDir = server.getWorldPath(LevelResource.ROOT).resolve("playerdata");
+        Path playerDataDir = server.getWorldPath(LevelResource.PLAYER_DATA_DIR);
         if (!java.nio.file.Files.isDirectory(playerDataDir)) return;
 
         try (DirectoryStream<Path> stream = java.nio.file.Files.newDirectoryStream(playerDataDir, "*.dat")) {

--- a/common/src/main/java/mc/smpessentials/regen/ChunkRegenManager.java
+++ b/common/src/main/java/mc/smpessentials/regen/ChunkRegenManager.java
@@ -19,8 +19,9 @@ import java.nio.file.Path;
 import java.util.*;
 
 // Queues and executes wilderness chunk regeneration at server shutdown.
-// Claimed chunks and a buffer zone around them are preserved; everything else
-// gets its header zeroed in the .mca files so Minecraft regenerates from seed.
+// Claimed chunks, the vanilla spawn protection area, and a buffer zone around
+// each are preserved; everything else gets its header zeroed in the .mca files
+// so Minecraft regenerates from seed.
 public final class ChunkRegenManager {
 
     private ChunkRegenManager() {}
@@ -60,6 +61,8 @@ public final class ChunkRegenManager {
             List<ClaimData> claims = readClaimsFromDisk(worldRoot);
             SmpUtilsMod.LOGGER.info("[QuackedSMP] Loaded {} claims from disk.", claims.size());
 
+            LongOpenHashSet spawnChunks = readSpawnProtectedChunks(worldRoot);
+
             // Group claims by dimension
             Map<String, List<ClaimData>> claimsByDim = new HashMap<>();
             for (ClaimData cd : claims) {
@@ -78,6 +81,9 @@ public final class ChunkRegenManager {
             for (String dimId : allDims) {
                 List<ClaimData> dimClaims = claimsByDim.getOrDefault(dimId, Collections.emptyList());
                 LongOpenHashSet protectedSet = buildProtectedSet(dimClaims);
+                if ("minecraft:overworld".equals(dimId)) {
+                    protectedSet.addAll(spawnChunks);
+                }
                 Path dimFolder = resolveDimensionFolder(worldRoot, dimId);
 
                 SmpUtilsMod.LOGGER.info("[QuackedSMP] {}: {} claims, {} protected chunks (with buffer={})",
@@ -116,7 +122,7 @@ public final class ChunkRegenManager {
     // Reads claims directly from the compressed NBT file on disk.
     // Returns an empty list if the file does not exist (no claims).
     private static List<ClaimData> readClaimsFromDisk(Path worldRoot) {
-        Path claimFile = worldRoot.resolve("data").resolve(CLAIMS_FILE);
+        Path claimFile = worldRoot.resolve("dimensions/minecraft/overworld/data/minecraft").resolve(CLAIMS_FILE);
         if (!Files.exists(claimFile)) {
             SmpUtilsMod.LOGGER.warn("[QuackedSMP] No claims file found -- all chunks will be regenerated.");
             return Collections.emptyList();
@@ -139,6 +145,67 @@ public final class ChunkRegenManager {
         }
     }
 
+    // Reads spawn center from level.dat and protection radius from server.properties,
+    // then returns the set of chunk positions within the spawn protection square + buffer.
+    // Returns an empty set if spawn protection is disabled or files cannot be read.
+    private static LongOpenHashSet readSpawnProtectedChunks(Path worldRoot) {
+        LongOpenHashSet set = new LongOpenHashSet();
+        Path normalizedRoot = worldRoot.toAbsolutePath().normalize();
+
+        // Read spawn-protection radius from server.properties
+        Path propsFile = normalizedRoot.getParent().resolve("server.properties");
+        if (!Files.exists(propsFile)) return set;
+
+        int radius;
+        try (var reader = Files.newBufferedReader(propsFile)) {
+            Properties props = new Properties();
+            props.load(reader);
+            String val = props.getProperty("spawn-protection", "16");
+            radius = Integer.parseInt(val.trim());
+        } catch (Exception e) {
+            SmpUtilsMod.LOGGER.warn("[QuackedSMP] Failed to read server.properties for spawn protection", e);
+            return set;
+        }
+        if (radius <= 0) return set;
+
+        // Read spawn position from level.dat
+        Path levelDat = normalizedRoot.resolve("level.dat");
+        if (!Files.exists(levelDat)) return set;
+
+        int spawnX, spawnZ;
+        try {
+            CompoundTag root = NbtIo.readCompressed(levelDat, NbtAccounter.unlimitedHeap());
+            Optional<CompoundTag> dataOpt = root.getCompound("Data");
+            if (dataOpt.isEmpty()) return set;
+            Optional<CompoundTag> spawnOpt = dataOpt.get().getCompound("spawn");
+            if (spawnOpt.isEmpty()) return set;
+            Optional<int[]> posOpt = spawnOpt.get().getIntArray("pos");
+            if (posOpt.isEmpty() || posOpt.get().length < 3) return set;
+            int[] pos = posOpt.get();
+            spawnX = pos[0];
+            spawnZ = pos[2];
+        } catch (IOException e) {
+            SmpUtilsMod.LOGGER.warn("[QuackedSMP] Failed to read level.dat for spawn position", e);
+            return set;
+        }
+
+        // Convert block-coord square to chunk coords, expand by buffer
+        int minChunkX = ((spawnX - radius) >> 4) - BUFFER;
+        int maxChunkX = ((spawnX + radius) >> 4) + BUFFER;
+        int minChunkZ = ((spawnZ - radius) >> 4) - BUFFER;
+        int maxChunkZ = ((spawnZ + radius) >> 4) + BUFFER;
+
+        for (int cx = minChunkX; cx <= maxChunkX; cx++) {
+            for (int cz = minChunkZ; cz <= maxChunkZ; cz++) {
+                set.add(new ChunkPos(cx, cz).pack());
+            }
+        }
+
+        SmpUtilsMod.LOGGER.info("[QuackedSMP] Spawn protection: center=({}, {}), radius={}, protecting {} chunks (with buffer={})",
+                spawnX, spawnZ, radius, set.size(), BUFFER);
+        return set;
+    }
+
     // Builds the set of chunk longs that must NOT be cleared.
     // Includes every claimed chunk plus a square buffer around each.
     private static LongOpenHashSet buildProtectedSet(List<ClaimData> claims) {
@@ -154,57 +221,29 @@ public final class ChunkRegenManager {
         return set;
     }
 
-    // Scans the world root to find all dimensions that have region data on disk.
+    // Scans dimensions/<namespace>/<path>/ for all dimensions that have region data on disk.
     private static Set<String> discoverDimensions(Path worldRoot) {
-        Set<String> dims = new LinkedHashSet<>();
-
-        // Overworld
-        if (Files.isDirectory(worldRoot.resolve("region"))) {
-            dims.add("minecraft:overworld");
-        }
-        // Nether
-        if (Files.isDirectory(worldRoot.resolve("DIM-1").resolve("region"))) {
-            dims.add("minecraft:the_nether");
-        }
-        // End
-        if (Files.isDirectory(worldRoot.resolve("DIM1").resolve("region"))) {
-            dims.add("minecraft:the_end");
-        }
-        // Custom dimensions: dimensions/<namespace>/<path>/region/
         Path dimsRoot = worldRoot.resolve("dimensions");
-        if (Files.isDirectory(dimsRoot)) {
-            try (DirectoryStream<Path> namespaces = Files.newDirectoryStream(dimsRoot)) {
-                for (Path ns : namespaces) {
-                    if (!Files.isDirectory(ns)) continue;
-                    try (DirectoryStream<Path> paths = Files.newDirectoryStream(ns)) {
-                        for (Path p : paths) {
-                            if (Files.isDirectory(p.resolve("region"))) {
-                                dims.add(ns.getFileName() + ":" + p.getFileName());
-                            }
-                        }
-                    }
-                }
-            } catch (IOException e) {
-                SmpUtilsMod.LOGGER.warn("[QuackedSMP] Failed to scan custom dimensions", e);
-            }
-        }
+        if (!Files.isDirectory(dimsRoot)) return new LinkedHashSet<>();
 
-        return dims;
+        try (var stream = Files.walk(dimsRoot, 2)) {
+            return stream
+                    .filter(p -> p.getNameCount() == dimsRoot.getNameCount() + 2)
+                    .filter(p -> Files.isDirectory(p.resolve("region")))
+                    .map(p -> p.getParent().getFileName() + ":" + p.getFileName())
+                    .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        } catch (IOException e) {
+            SmpUtilsMod.LOGGER.warn("[QuackedSMP] Failed to scan dimensions", e);
+            return new LinkedHashSet<>();
+        }
     }
 
-    // Maps a dimension ID string to its filesystem folder.
+    // Maps a dimension ID (e.g. "minecraft:overworld") to its filesystem folder.
     static Path resolveDimensionFolder(Path worldRoot, String dimId) {
-        return switch (dimId) {
-            case "minecraft:overworld" -> worldRoot;
-            case "minecraft:the_nether" -> worldRoot.resolve("DIM-1");
-            case "minecraft:the_end" -> worldRoot.resolve("DIM1");
-            default -> {
-                int colon = dimId.indexOf(':');
-                String namespace = colon > 0 ? dimId.substring(0, colon) : "minecraft";
-                String path = colon > 0 ? dimId.substring(colon + 1) : dimId;
-                yield worldRoot.resolve("dimensions").resolve(namespace).resolve(path);
-            }
-        };
+        int colon = dimId.indexOf(':');
+        String namespace = colon > 0 ? dimId.substring(0, colon) : "minecraft";
+        String path = colon > 0 ? dimId.substring(colon + 1) : dimId;
+        return worldRoot.resolve("dimensions").resolve(namespace).resolve(path);
     }
 
     // Processes all .mca files in a directory. Returns {filesProcessed, chunksCleared, filesDeleted}.

--- a/fabric/src/main/java/mc/smpessentials/fabric/SmpUtilsModFabric.java
+++ b/fabric/src/main/java/mc/smpessentials/fabric/SmpUtilsModFabric.java
@@ -46,11 +46,8 @@ public final class SmpUtilsModFabric implements ModInitializer {
             mc.smpessentials.dashboard.DashboardManager.onServerStop();
             mc.smpessentials.votifier.VotifierListener.stop();
         });
-        // SERVER_STOPPED fires after level.dat is written — safe to patch it here.
-        // Chunk regen runs first (needs dimension data intact), then scrubLevelDat cleans up deleted custom dims.
         net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents.SERVER_STOPPED.register(server -> {
             mc.smpessentials.regen.ChunkRegenManager.onServerStopped(server);
-            mc.smpessentials.dims.DimManager.scrubLevelDat(server);
 
             mc.smpessentials.SmpUtilsMod.scheduleExitGuard();
         });

--- a/neoforge/src/main/java/mc/smpessentials/neoforge/SmpEvents.java
+++ b/neoforge/src/main/java/mc/smpessentials/neoforge/SmpEvents.java
@@ -65,7 +65,6 @@ public class SmpEvents {
     @SubscribeEvent
     public static void onServerStopped(ServerStoppedEvent event) {
         mc.smpessentials.regen.ChunkRegenManager.onServerStopped(event.getServer());
-        mc.smpessentials.dims.DimManager.scrubLevelDat(event.getServer());
 
         mc.smpessentials.SmpUtilsMod.scheduleExitGuard();
     }


### PR DESCRIPTION
                                                                                                                                                                                                                                                                         
  ChunkRegenManager.java:                                                                                                                                                                                                                                                  
  - Wilderness regen now discovers all dimensions correctly (was missing overworld, nether, end entirely)
  - Claims are loaded from the correct 26.x SavedData path                                                                                                                                                                                                                 
  - Spawn protection area is now preserved during regen (reads spawn pos + radius from level.dat and server.properties)                                                                                                                                                  
  - Dimension folder resolution uses the new dimensions/<namespace>/<path> layout                                                                                                                                                                                          
                                                                                                                                                                                                                                                                           
  DimManager.java:                                                                                                                                                                                                                                                         
  - Offline player relocation uses correct 26.x player data path (LevelResource.PLAYER_DATA_DIR)                                                                                                                                                                           
  - Removed dead scrubLevelDat code (WorldGenSettings no longer exists in 26.x)                                                                                                                                                                                            
                                                                                                                                                                                                                                                                         
  EndResetLogic.java:                                                                                                                                                                                                                                                      
  - End terrain reset uses correct 26.x path (dimensions/minecraft/the_end instead of DIM1)                                                                                                                                                                                
  - Now also clears the entities subfolder (new in 26.x)    